### PR TITLE
chore: grandpa justification

### DIFF
--- a/query/app/api/justification/route.ts
+++ b/query/app/api/justification/route.ts
@@ -1,7 +1,7 @@
 import { DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb';
 import { NextRequest, NextResponse } from 'next/server';
 
-const tableName = 'justifications';
+const tableName = 'justifications/v2';
 
 /** Get the justification for a given Avail block.
  * - blockNumber: The block number of the Avail block.

--- a/query/app/api/justification/route.ts
+++ b/query/app/api/justification/route.ts
@@ -1,7 +1,7 @@
 import { DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb';
 import { NextRequest, NextResponse } from 'next/server';
 
-const tableName = 'justifications/v2';
+const tableName = 'justifications-v2';
 
 /** Get the justification for a given Avail block.
  * - blockNumber: The block number of the Avail block.

--- a/render.yaml
+++ b/render.yaml
@@ -51,6 +51,10 @@ services:
         value: 11155111
       - key: CONTRACT_ADDRESS
         value: 0xEA5b658054Cc3646044770d60cfC4e17c5cA1c7d
+      - key: BLOCK_UPDATE_INTERVAL
+        value: 30
+      - key: LOOP_DELAY_MINS
+        value: 5
       - key: PRIVATE_KEY
         sync: false
       - key: RPC_URL

--- a/render.yaml
+++ b/render.yaml
@@ -61,3 +61,49 @@ services:
         sync: false
       - key: SP1_PRIVATE_KEY
         sync: false
+  - type: worker
+    runtime: rust
+    name: indexer-hex
+    repo: https://github.com/succinctlabs/sp1-vectorx
+    region: frankfurt
+    plan: standard
+    rootDir: services
+    buildCommand: cargo build --bin indexer --release
+    startCommand: cargo run --bin indexer --release
+    autoDeploy: true
+    envVars:
+      - key: AVAIL_URL
+        value: wss://rpc-hex-devnet.avail.tools/ws
+      - key: AVAIL_CHAIN_ID
+        value: hex
+      - key: AWS_ACCESS_KEY_ID
+        sync: false
+      - key: AWS_REGION
+        sync: false
+      - key: AWS_SECRET_ACCESS_KEY
+        sync: false
+      - key: KEY_ID
+        sync: false
+  - type: worker
+    runtime: rust
+    name: indexer-turing
+    repo: https://github.com/succinctlabs/sp1-vectorx
+    region: frankfurt
+    plan: standard
+    rootDir: services
+    buildCommand: cargo build --bin indexer --release
+    startCommand: cargo run --bin indexer --release
+    autoDeploy: true
+    envVars:
+      - key: AVAIL_URL
+        value: wss://turing-rpc.avail.so/ws
+      - key: AVAIL_CHAIN_ID
+        value: turing
+      - key: AWS_ACCESS_KEY_ID
+        sync: false
+      - key: AWS_REGION
+        sync: false
+      - key: AWS_SECRET_ACCESS_KEY
+        sync: false
+      - key: KEY_ID
+        sync: false

--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,7 @@ services:
   - type: worker
     runtime: rust
     name: sp1-vectorx-operator-eu
-    repo: https://github.com/succinctlabs/sp1-vectorx
+    repo: https://github.com/succinctlabs/sp1-vector
     region: frankfurt
     plan: standard
     rootDir: script
@@ -31,7 +31,7 @@ services:
   - type: worker
     runtime: rust
     name: sp1-vectorx-operator-hex
-    repo: https://github.com/succinctlabs/sp1-vectorx
+    repo: https://github.com/succinctlabs/sp1-vector
     region: frankfurt
     plan: standard
     rootDir: script
@@ -64,7 +64,7 @@ services:
   - type: worker
     runtime: rust
     name: indexer-hex
-    repo: https://github.com/succinctlabs/sp1-vectorx
+    repo: https://github.com/succinctlabs/sp1-vector
     region: frankfurt
     plan: standard
     rootDir: services
@@ -87,7 +87,7 @@ services:
   - type: worker
     runtime: rust
     name: indexer-turing
-    repo: https://github.com/succinctlabs/sp1-vectorx
+    repo: https://github.com/succinctlabs/sp1-vector
     region: frankfurt
     plan: standard
     rootDir: services

--- a/script/src/lib.rs
+++ b/script/src/lib.rs
@@ -8,7 +8,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_justification_query_service() -> Result<()> {
         let client = RpcDataFetcher::new().await;
-        let justification = client.get_justification("turing", 337281).await?;
+        let justification = client.get_justification(337281).await?;
         println!("Justification: {:?}", justification);
         Ok(())
     }

--- a/services/bin/indexer.rs
+++ b/services/bin/indexer.rs
@@ -1,14 +1,8 @@
-use std::collections::HashMap;
-
-use avail_subxt::config::Header as HeaderTrait;
-use avail_subxt::{api, RpcParams};
-use codec::Encode;
+use avail_subxt::RpcParams;
 use log::debug;
 use services::aws::AWSClient;
 use services::input::RpcDataFetcher;
-use services::types::{GrandpaJustification, SignerMessage, StoredJustificationData};
-use sp_core::ed25519::{self};
-use sp_core::{blake2_256, Pair, H256};
+use services::types::GrandpaJustification;
 use subxt::backend::rpc::RpcSubscription;
 
 async fn listen_for_justifications(fetcher: RpcDataFetcher, aws_client: AWSClient) {
@@ -30,113 +24,8 @@ async fn listen_for_justifications(fetcher: RpcDataFetcher, aws_client: AWSClien
             justification.commit.target_number
         );
 
-        // Get the header corresponding to the new justification.
-        let header = fetcher
-            .client
-            .legacy_rpc()
-            .chain_get_header(Some(justification.commit.target_hash))
-            .await
-            .unwrap()
-            .unwrap();
-
-        // A bit redundant, but just to make sure the hash is correct. This confirms that the
-        // header encoding + block encoding match.
-        let block_hash = justification.commit.target_hash;
-        let header_hash = header.hash();
-        let calculated_hash: H256 = Encode::using_encoded(&header, blake2_256).into();
-        if header_hash != calculated_hash || block_hash != calculated_hash {
-            panic!("Header hash does not match block hash, avail-subxt crate is out of sync.");
-        }
-
-        // Get current authority set ID.
-        let set_id_key = api::storage().grandpa().current_set_id();
-        let authority_set_id = fetcher
-            .client
-            .storage()
-            .at(block_hash)
-            .fetch(&set_id_key)
-            .await
-            .unwrap()
-            .unwrap();
-
-        // Form a message which is signed in the justification.
-        let signed_message = Encode::encode(&(
-            &SignerMessage::PrecommitMessage(justification.commit.precommits[0].clone().precommit),
-            &justification.round,
-            &authority_set_id,
-        ));
-
-        // Verify all the signatures of the justification and extract the public keys. The ordering
-        // of the authority set will already be canonical and sorted in the justification on ID.
-
-        let validators = justification
-            .commit
-            .precommits
-            .iter()
-            .filter_map(|precommit| {
-                let is_ok = <ed25519::Pair as Pair>::verify(
-                    &precommit.clone().signature,
-                    signed_message.as_slice(),
-                    &precommit.clone().id,
-                );
-                if is_ok {
-                    Some((
-                        precommit.clone().id.0.to_vec(),
-                        precommit.clone().signature.0.to_vec(),
-                    ))
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
-
-        let pubkeys = validators.iter().map(|v| v.0.clone()).collect::<Vec<_>>();
-        let signatures = validators.iter().map(|v| v.1.clone()).collect::<Vec<_>>();
-
-        // Create map from pubkey to signature.
-        let mut pubkey_to_signature = HashMap::new();
-        for (pubkey, signature) in pubkeys.iter().zip(signatures.iter()) {
-            pubkey_to_signature.insert(pubkey.to_vec(), signature.to_vec());
-        }
-
-        // Check that more than 2/3 of the validators signed the justification.
-        // Note: Assumes the validator set have equal voting power.
-        let authorities = fetcher.get_authorities(header.number - 1).await;
-        let num_authorities = authorities.len();
-        let signed_count = pubkeys.len();
-        let required_signatures = (num_authorities * 2) / 3;
-        if signed_count <= required_signatures {
-            continue;
-        }
-
-        // Create justification data.
-        let mut justification_pubkeys = Vec::new();
-        let mut justification_signatures = Vec::new();
-        let mut validator_signed = Vec::new();
-        for authority_pubkey in authorities.iter() {
-            if let Some(signature) = pubkey_to_signature.get(authority_pubkey.0.as_slice()) {
-                justification_pubkeys.push(authority_pubkey.0.to_vec());
-                justification_signatures.push(signature.to_vec());
-                validator_signed.push(true);
-            } else {
-                justification_pubkeys.push(authority_pubkey.0.to_vec());
-                justification_signatures.push([0u8; 64].to_vec());
-                validator_signed.push(false);
-            }
-        }
-
-        // Add justification to DB.
-        let store_justification_data = StoredJustificationData {
-            block_number: header.number,
-            signed_message: signed_message.clone(),
-            pubkeys: justification_pubkeys,
-            signatures: justification_signatures,
-            num_authorities: authorities.len(),
-            validator_signed,
-        };
-
         aws_client
-            .add_justification(&fetcher.avail_chain_id, store_justification_data)
+            .add_justification(&fetcher.avail_chain_id, justification)
             .await
             .unwrap();
     }

--- a/services/src/aws.rs
+++ b/services/src/aws.rs
@@ -6,13 +6,13 @@ use log::info;
 use serde_json::{from_str, to_string};
 use std::collections::HashMap;
 
-use crate::types::StoredJustificationData;
+use crate::types::GrandpaJustification;
 
 pub struct AWSClient {
     client: Client,
 }
 
-const JUSTIFICATION_TABLE: &str = "justifications";
+const JUSTIFICATION_TABLE: &str = "justifications/v2";
 
 impl AWSClient {
     pub async fn new() -> Self {
@@ -25,11 +25,11 @@ impl AWSClient {
     pub async fn add_justification(
         &self,
         avail_chain_id: &str,
-        justification: StoredJustificationData,
+        justification: GrandpaJustification,
     ) -> Result<()> {
         let json_data = to_string(&justification)?;
 
-        let block_nb = justification.block_number;
+        let block_nb = justification.commit.target_number;
         let key = format!("{}-{}", avail_chain_id, block_nb).to_lowercase();
 
         let item = HashMap::from([
@@ -53,7 +53,7 @@ impl AWSClient {
         &self,
         avail_chain_id: &str,
         block_number: u32,
-    ) -> Result<StoredJustificationData> {
+    ) -> Result<GrandpaJustification> {
         let key = format!("{}-{}", avail_chain_id, block_number).to_lowercase();
 
         let resp = self
@@ -67,7 +67,7 @@ impl AWSClient {
         if let Some(item) = resp.item {
             if let Some(data_attr) = item.get("data") {
                 if let Ok(data_json) = data_attr.as_s() {
-                    let data: StoredJustificationData = from_str(data_json)?;
+                    let data: GrandpaJustification = from_str(data_json)?;
                     return Ok(data);
                 }
             }

--- a/services/src/aws.rs
+++ b/services/src/aws.rs
@@ -12,7 +12,7 @@ pub struct AWSClient {
     client: Client,
 }
 
-const JUSTIFICATION_TABLE: &str = "justifications/v2";
+const JUSTIFICATION_TABLE: &str = "justifications-v2";
 
 impl AWSClient {
     pub async fn new() -> Self {

--- a/services/src/input.rs
+++ b/services/src/input.rs
@@ -13,10 +13,7 @@ use std::collections::HashMap;
 use std::env;
 use subxt::backend::rpc::RpcSubscription;
 
-use crate::types::{
-    EncodedFinalityProof, FinalityProof, GrandpaJustification, SignerMessage,
-    StoredJustificationData,
-};
+use crate::types::{EncodedFinalityProof, FinalityProof, GrandpaJustification, SignerMessage};
 use alloy_primitives::{B256, B512};
 use avail_subxt::avail_client::AvailClient;
 use avail_subxt::config::substrate::DigestItem;
@@ -49,12 +46,12 @@ impl RpcDataFetcher {
         }
     }
 
-    /// Gets a justification from the vectorx-query service.
+    /// Gets a justification from the vectorx-query service, which reads the data from the AWS DB.
     pub async fn get_justification(
         &self,
         avail_chain_id: &str,
         block_number: u32,
-    ) -> Result<StoredJustificationData> {
+    ) -> Result<GrandpaJustification> {
         let base_justification_query_url = format!("{}/api/justification", self.vectorx_query_url);
 
         let request_url = format!(
@@ -71,8 +68,7 @@ impl RpcDataFetcher {
             .ok_or_else(|| anyhow::anyhow!("Justification field should be a string"))?
             .as_str()
             .ok_or_else(|| anyhow::anyhow!("Justification field should be a string"))?;
-        let justification_data =
-            serde_json::from_str::<StoredJustificationData>(justification_str)?;
+        let justification_data = serde_json::from_str::<GrandpaJustification>(justification_str)?;
 
         Ok(justification_data)
     }
@@ -357,55 +353,21 @@ impl RpcDataFetcher {
     ) -> Option<(CircuitJustification, Header)> {
         // Note: The db justification type is from VectorX, and we need to map it onto the
         // CircuitJustification SP1 VectorX type.
-        let stored_justification = self
+        let grandpa_justification = self
             .get_justification(&self.avail_chain_id, block_number)
             .await;
 
-        if stored_justification.is_err() {
+        if grandpa_justification.is_err() {
             return None;
         }
+        let grandpa_justification = grandpa_justification.unwrap();
 
-        let stored_justification = stored_justification.unwrap();
-
-        let block_hash = self.get_block_hash(stored_justification.block_number).await;
-
-        let authority_set_id = self
-            .get_authority_set_id(stored_justification.block_number - 1)
-            .await;
-        let authority_set_hash = self
-            .compute_authority_set_hash_for_block(stored_justification.block_number - 1)
-            .await;
-        let header = self.get_header(stored_justification.block_number).await;
-
-        // Convert pubkeys from DB into [u8; 32]
-        let pubkeys: Vec<B256> = stored_justification
-            .pubkeys
-            .iter()
-            .map(|pubkey| B256::from_slice(pubkey.clone().as_slice()))
-            .collect();
-
-        let mut signatures: Vec<Option<B512>> = Vec::new();
-        for i in 0..stored_justification.signatures.len() {
-            if stored_justification.validator_signed[i] {
-                signatures.push(Some(B512::from_slice(
-                    stored_justification.signatures[i].clone().as_slice(),
-                )));
-            } else {
-                signatures.push(None);
-            }
-        }
+        let header = self.get_header(block_number).await;
 
         // Convert DB stored justification into CircuitJustification.
-        let circuit_justification = CircuitJustification {
-            signed_message: stored_justification.signed_message,
-            authority_set_id,
-            current_authority_set_hash: authority_set_hash,
-            pubkeys,
-            signatures,
-            num_authorities: stored_justification.num_authorities,
-            block_number: stored_justification.block_number,
-            block_hash,
-        };
+        let circuit_justification = self
+            .compute_data_from_justification(grandpa_justification, block_number)
+            .await;
         Some((circuit_justification, header))
     }
 

--- a/services/src/types.rs
+++ b/services/src/types.rs
@@ -6,14 +6,14 @@ use sp_core::ed25519::{Public as EdPublic, Signature};
 use sp_core::H256;
 use sp_core::{bytes, Bytes};
 
-#[derive(Clone, Debug, Decode, Encode, Deserialize)]
+#[derive(Clone, Debug, Decode, Encode, Serialize, Deserialize)]
 pub struct Precommit {
     pub target_hash: H256,
     /// The target block's number
     pub target_number: u32,
 }
 
-#[derive(Clone, Debug, Decode, Deserialize)]
+#[derive(Clone, Debug, Decode, Serialize, Deserialize)]
 pub struct SignedPrecommit {
     pub precommit: Precommit,
     /// The signature on the message.
@@ -22,7 +22,7 @@ pub struct SignedPrecommit {
     pub id: EdPublic,
 }
 
-#[derive(Clone, Debug, Decode, Deserialize)]
+#[derive(Clone, Debug, Decode, Serialize, Deserialize)]
 pub struct Commit {
     pub target_hash: H256,
     #[allow(dead_code)]
@@ -32,7 +32,7 @@ pub struct Commit {
     pub precommits: Vec<SignedPrecommit>,
 }
 
-#[derive(Clone, Debug, Decode)]
+#[derive(Clone, Debug, Decode, Serialize)]
 pub struct GrandpaJustification {
     pub round: u64,
     pub commit: Commit,
@@ -69,15 +69,4 @@ pub struct FinalityProof {
     pub justification: Vec<u8>,
     /// The set of headers in the range (B; F] that are unknown to the caller, ordered by block number.
     pub unknown_headers: Vec<Header>,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-/// Stored justification data in DB.
-pub struct StoredJustificationData {
-    pub block_number: u32,
-    pub signed_message: Vec<u8>,
-    pub pubkeys: Vec<Vec<u8>>,
-    pub signatures: Vec<Vec<u8>>,
-    pub validator_signed: Vec<bool>,
-    pub num_authorities: usize,
 }


### PR DESCRIPTION
- Store grandpa justifications retrieved from the subscriber of the tip of the Avail chain directly to the DB.
- Add the indexer configurations to `render.yaml`
- Logging refactor.