### PR TITLE
feat: add approved relayer to contracts

### DIFF
--- a/contracts/src/SP1Vector.sol
+++ b/contracts/src/SP1Vector.sol
@@ -59,6 +59,12 @@ contract SP1Vector is ISP1Vector, TimelockedUpgradeable {
     /// @notice The deployed SP1 verifier contract.
     ISP1Verifier public verifier;
 
+    /// @notice Approved relayers for the contract.
+    mapping(address => bool) public approvedRelayers;
+
+    /// @notice Check the relayer is approved.
+    bool public checkRelayer = true;
+
     /// @notice The type of proof that is being verified.
     enum ProofType {
         HeaderRangeProof,
@@ -98,6 +104,14 @@ contract SP1Vector is ISP1Vector, TimelockedUpgradeable {
         ProofType proofType;
         bytes headerRangeOutputs;
         bytes rotateOutputs;
+    }
+
+    /// @notice If the relayer check is enabled, only approved relayers can call the function.
+    modifier onlyApprovedRelayer() {
+        if (!checkRelayer || approvedRelayers[msg.sender]) {
+            revert RelayerNotApproved();
+        }
+        _;
     }
 
     function VERSION() external pure override returns (string memory) {
@@ -193,12 +207,22 @@ contract SP1Vector is ISP1Vector, TimelockedUpgradeable {
         latestAuthoritySetId = _endAuthoritySetId;
     }
 
+    /// @notice Approve a relayer.
+    function approveRelayer(address _relayer) external onlyGuardian {
+        approvedRelayers[_relayer] = true;
+    }
+
+    /// @notice Set the relayer check.
+    function setRelayerCheck(bool _checkRelayer) external onlyGuardian {
+        checkRelayer = _checkRelayer;
+    }
+
     /// @notice Add target header hash, and data + state commitments for (latestBlock, targetBlock].
     /// @param proof The proof bytes for the SP1 proof.
     /// @param publicValues The public commitments from the SP1 proof.
     /// @dev The trusted block and requested block must have the same authority set id. If the target
     /// block is greater than the max batch size of the circuit, the proof will fail to generate.
-    function commitHeaderRange(bytes calldata proof, bytes calldata publicValues) external {
+    function commitHeaderRange(bytes calldata proof, bytes calldata publicValues) external onlyApprovedRelayer {
         if (frozen) {
             revert ContractFrozen();
         }
@@ -283,7 +307,7 @@ contract SP1Vector is ISP1Vector, TimelockedUpgradeable {
     /// @notice Adds the authority set hash for the next authority set id.
     /// @param proof The proof bytes for the SP1 proof.
     /// @param publicValues The public commitments from the SP1 proof.
-    function rotate(bytes calldata proof, bytes calldata publicValues) external {
+    function rotate(bytes calldata proof, bytes calldata publicValues) external onlyApprovedRelayer {
         if (frozen) {
             revert ContractFrozen();
         }

--- a/contracts/src/SP1Vector.sol
+++ b/contracts/src/SP1Vector.sol
@@ -212,9 +212,9 @@ contract SP1Vector is ISP1Vector, TimelockedUpgradeable {
         approvedRelayers[_relayer] = true;
     }
 
-    /// @notice Set the relayer check.
-    function setRelayerCheck(bool _checkRelayer) external onlyGuardian {
-        checkRelayer = _checkRelayer;
+    /// @notice Set a relayer's approval status.
+    function setRelayerApproval(address _relayer, bool _approved) external onlyGuardian {
+        approvedRelayers[_relayer] = _approved;
     }
 
     /// @notice Add target header hash, and data + state commitments for (latestBlock, targetBlock].

--- a/contracts/src/SP1Vector.sol
+++ b/contracts/src/SP1Vector.sol
@@ -63,7 +63,7 @@ contract SP1Vector is ISP1Vector, TimelockedUpgradeable {
     mapping(address => bool) public approvedRelayers;
 
     /// @notice Check the relayer is approved.
-    bool public checkRelayer = true;
+    bool public checkRelayer = false;
 
     /// @notice The type of proof that is being verified.
     enum ProofType {

--- a/contracts/src/SP1Vector.sol
+++ b/contracts/src/SP1Vector.sol
@@ -207,11 +207,6 @@ contract SP1Vector is ISP1Vector, TimelockedUpgradeable {
         latestAuthoritySetId = _endAuthoritySetId;
     }
 
-    /// @notice Approve a relayer.
-    function approveRelayer(address _relayer) external onlyGuardian {
-        approvedRelayers[_relayer] = true;
-    }
-
     /// @notice Set a relayer's approval status.
     function setRelayerApproval(address _relayer, bool _approved) external onlyGuardian {
         approvedRelayers[_relayer] = _approved;

--- a/contracts/src/SP1Vector.sol
+++ b/contracts/src/SP1Vector.sol
@@ -108,7 +108,7 @@ contract SP1Vector is ISP1Vector, TimelockedUpgradeable {
 
     /// @notice If the relayer check is enabled, only approved relayers can call the function.
     modifier onlyApprovedRelayer() {
-        if (!checkRelayer || approvedRelayers[msg.sender]) {
+        if (checkRelayer && !approvedRelayers[msg.sender]) {
             revert RelayerNotApproved();
         }
         _;

--- a/contracts/src/interfaces/ISP1Vector.sol
+++ b/contracts/src/interfaces/ISP1Vector.sol
@@ -65,4 +65,7 @@ interface ISP1Vector {
 
     /// @notice Target block is not greater than the latest block.
     error InvalidTargetBlock();
+
+    /// @notice Relayer not approved.
+    error RelayerNotApproved();
 }


### PR DESCRIPTION
Add approved relaying to the contract. This feature needs to be turned on, and restricts the accounts that can relay to `commitHeaderRange` and `rotate`.