### PR TITLE
fix(rotate): Handle consensus logs that are not `ScheduledChange`

### DIFF
--- a/primitives/src/rotate.rs
+++ b/primitives/src/rotate.rs
@@ -62,7 +62,7 @@ fn verify_encoding_epoch_end_header(
         decode_scale_compact_int(header_bytes[cursor..cursor + 5].to_vec());
     cursor += decoded_byte_length;
 
-    // Verify the next byte after encoded scheduled change message is scheduled change enum flags.
+    // Verify the next byte after encoded scheduled change message is the ScheduledChange enum flag.
     assert_eq!(header_bytes[cursor], 1u8);
 
     cursor += 1;

--- a/script/bin/test.rs
+++ b/script/bin/test.rs
@@ -16,11 +16,11 @@ async fn main() -> anyhow::Result<()> {
     setup_logger();
 
     // Supply an initial authority set id, trusted block, and target block.
-    let authority_set_id = 64u64;
+    let authority_set_id = 282u64;
     let trusted_block = 305130;
     let target_block = 305160;
 
-    let proof_type = ProofType::HeaderRangeProof;
+    let proof_type = ProofType::RotateProof;
 
     let fetcher = RpcDataFetcher::new().await;
     let mut stdin: SP1Stdin = SP1Stdin::new();

--- a/services/src/input.rs
+++ b/services/src/input.rs
@@ -460,6 +460,7 @@ impl RpcDataFetcher {
     /// position of the encoded new authority set in the header.
     pub async fn get_header_rotate(&self, authority_set_id: u64) -> HeaderRotateData {
         let epoch_end_block = self.last_justified_block(authority_set_id).await;
+        println!("epoch_end_block {:?}", epoch_end_block);
         if epoch_end_block == 0 {
             panic!("Current authority set is still active!");
         }
@@ -486,8 +487,8 @@ impl RpcDataFetcher {
                 if consensus_id == [70, 82, 78, 75] {
                     found_correct_log = true;
 
-                    // Denotes that this is a `ScheduledChange` log.
-                    assert_eq!(value[0], 1);
+                    // // Denotes that this is a `ScheduledChange` log.
+                    // assert_eq!(value[0], 1);
 
                     // The bytes after the prefix are the compact encoded number of authorities.
                     // Follows the encoding format: https://docs.substrate.io/reference/scale-codec/#fn-1

--- a/services/src/input.rs
+++ b/services/src/input.rs
@@ -538,11 +538,11 @@ impl RpcDataFetcher {
                             println!("Found ForcedChange log!");
                             found_correct_log = true;
                         }
-                        _ => continue,
+                        _ => {
+                            position += encoded_log.len();
+                            continue;
+                        }
                     }
-
-                    // // Denotes that this is a `ScheduledChange` log.
-                    // assert_eq!(value[0], 1);
 
                     // The bytes after the prefix are the compact encoded number of authorities.
                     // Follows the encoding format: https://docs.substrate.io/reference/scale-codec/#fn-1

--- a/services/src/input.rs
+++ b/services/src/input.rs
@@ -168,15 +168,6 @@ impl RpcDataFetcher {
             .get_justification_data_epoch_end_block(authority_set_id)
             .await;
 
-        let auth_set_changes = self.filter_auth_set_changes(authority_set_id).await;
-        // println!("auth_set_changes {:?}", auth_set_changes.len());
-
-        for auth_set_change in auth_set_changes {
-            for (pubkey, weight) in auth_set_change {
-                // println!("pubkey {:?} weight {:?}", pubkey.0 .0 .0, weight);
-            }
-        }
-
         let header_rotate_data = self.get_header_rotate(authority_set_id).await;
 
         RotateInputs {
@@ -465,12 +456,14 @@ impl RpcDataFetcher {
             .await
     }
 
+    /// Filter the authority set changes from the header at the end of the epoch associated with the
+    /// given authority set id.
+    /// Source: https://github.com/Rahul8869/avail-light/blob/1ee54e10c037474d2ee99a0762e6ffee43f0df1c/src/utils.rs#L78
     pub async fn filter_auth_set_changes(
         &self,
         authority_set_id: u64,
     ) -> Vec<Vec<(AuthorityId, u64)>> {
         let epoch_end_block = self.last_justified_block(authority_set_id).await;
-        println!("epoch_end_block {:?}", epoch_end_block);
         if epoch_end_block == 0 {
             panic!("Current authority set is still active!");
         }
@@ -482,7 +475,6 @@ impl RpcDataFetcher {
             .logs
             .iter()
             .filter_map(|e| match &e {
-                // UGHHH, why won't the b"FRNK" just work
                 avail_subxt::config::substrate::DigestItem::Consensus(
                     [b'F', b'R', b'N', b'K'],
                     data,
@@ -503,7 +495,6 @@ impl RpcDataFetcher {
     /// position of the encoded new authority set in the header.
     pub async fn get_header_rotate(&self, authority_set_id: u64) -> HeaderRotateData {
         let epoch_end_block = self.last_justified_block(authority_set_id).await;
-        println!("epoch_end_block {:?}", epoch_end_block);
         if epoch_end_block == 0 {
             panic!("Current authority set is still active!");
         }


### PR DESCRIPTION
There are two consensus logs that can trigger a change in the authority set, the `ScheduledChange` log and the `ForcedChange` log.

Previously, we did not handle the cases for the other logs: https://paritytech.github.io/polkadot-sdk/master/src/sp_consensus_grandpa/lib.rs.html#152-194.

In a future PR, we should modify the program to add support for `ForcedChange` consensus log, as it only supports `ScheduledChange`. This PR simply parses the consensus logs correctly, skipping logs such as `OnDisabled`, until a `ScheduledChange` or `ForcedChange` log is found.