### PR TITLE
fix: Adds new hex contract deployment info

### DIFF
--- a/query/app/utils/deployments.json
+++ b/query/app/utils/deployments.json
@@ -41,6 +41,12 @@
             "contractAddress": "0xbc281367e1F2dB1c3e92255AA2F040B1c642ec75",
             "cursorStartBlock": 6204379,
             "availChainId": "hex"
+        },
+        {
+            "contractChainId": 11155111,
+            "contractAddress": "0x054fd961708d8e2b9c10a63f6157c74458889f0a",
+            "cursorStartBlock": 9215487,
+            "availChainId": "hex"
         }
     ]
 }


### PR DESCRIPTION
# Problem Statement
Failing requests on range endpoint due to missing new hex contract config.

Set cursor at [9215477](https://sepolia.etherscan.io/block/9215477) + 10 blocks due to [update genesis state](https://sepolia.etherscan.io/tx/0x3183fa9acdf245e5a47930fe3c0166247a60e557cc5ba3cd64105a835a609a43) call