### PR TITLE
fix: Adds client user agent

### DIFF
--- a/services/src/input.rs
+++ b/services/src/input.rs
@@ -559,7 +559,11 @@ pub async fn fetch_usd_rate() -> Result<CoingekoApiResponse> {
         "{}/v3/simple/price?ids={}&vs_currencies={}&x_cg_api_key={}",
         coingeko_url, from_token, "usd", coingeko_api_key
     );
-    let response = reqwest::get(price_endpoint).await.unwrap();
+    let client = reqwest::Client::builder()
+        .user_agent("Avail-SP1-Vector/1.0 (Ethereum Gas Price Monitor)")
+        .build()?;
+
+    let response = client.get(price_endpoint).send().await.unwrap();
 
     Ok(response.json::<CoingekoApiResponse>().await?)
 }


### PR DESCRIPTION
# Problem
- Coingecko API introduced a request gate that prevents request on empty user-agent


# How this was tested

An empty header curl request was made to reproduce the behavior.

```sh
╰─$ curl -s "https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd&x_cg_api_key=<REDACTED>" -H "user-agent:" | jq .

{
  "status": {
    "error_code": 403,
    "error_message": "Please add a descriptive User-Agent to your request. For higher rate limits & stable integration, please subscribe to our API plans: https://www.coingecko.com/en/api/pricing . If you think this is a mistake, please report here: https://forms.gle/3V2z8Mb3k2RMu5S2A"
  }
}
```