### PR TITLE
ci: build and publish operator image to vector-operator-job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
-# Builds the `indexer` bin from the `services` crate via docker/Dockerfile (BIN_MODE),
-# renamed to `vectorx-indexer`, and pushes to registry.digitalocean.com/availj.
-name: Release vectorx-indexer
+# Builds release images from docker/Dockerfile (BIN_MODE selects the bin) and pushes to
+# registry.digitalocean.com/availj:
+#   - indexer  (services crate) -> vectorx-indexer
+#   - operator (script crate)   -> vector-operator-job  (consumed by sp1-*-vector-fallback-job)
+name: Release vectorx images
 
 on:
   push:
@@ -15,13 +17,17 @@ on:
 
 jobs:
   docker_build_push:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: true
       matrix:
-        # The services crate currently exposes only the `indexer` bin.
-        # Add more here (e.g. operator) once they exist as [[bin]] targets.
-        binary: [indexer]
+        include:
+          # indexer bin (services crate) -> availj/vectorx-indexer
+          - binary: indexer
+            image: vectorx-indexer
+          # operator bin (script crate) -> availj/vector-operator-job
+          - binary: operator
+            image: vector-operator-job
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -56,7 +62,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ${{ steps.meta.outputs.do_registry }}/availj/vectorx-${{ matrix.binary }}:${{ steps.meta.outputs.tag_name }}
+            ${{ steps.meta.outputs.do_registry }}/availj/${{ matrix.image }}:${{ steps.meta.outputs.tag_name }}
           build-args: |
             BUILD_PROFILE=release
             BIN_MODE=${{ matrix.binary }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ RUN apt update && apt install -y git make libssl-dev pkg-config libpq-dev \
 FROM ubuntu:22.04 AS run
 WORKDIR /app
 ARG BIN_MODE=indexer
-ENV BIN_MODE_ENV=indexer
+ENV BIN_MODE_ENV=$BIN_MODE
 
 COPY --from=builder /build/vectorx-$BIN_MODE /usr/local/bin
 


### PR DESCRIPTION
## Problem
The release workflow only builds the `indexer` bin → `availj/vectorx-indexer`. The `sp1-*-vector-fallback-job` deployments (turing + mainnet) consume **`availj/vector-operator-job`**, which has had no build since the CI consolidation (tops out at `v1.11.0-fix`, Apr 2026). Bumping helm to `v2.0.0-rc2` therefore caused a permanent `ImagePullBackOff` on those CronJobs.

## Root cause confirmed
Pulled the `vector-operator-job:v1.11.0-fix` image config — it was built from **this same `docker/Dockerfile` with `BIN_MODE=operator`** (COPY `/build/vectorx-operator` → `/usr/local/bin`, entrypoint `/usr/local/bin/vectorx-operator`, matching the job's `customEntrypoint`). The build recipe still exists; only the CI wiring to produce it was dropped.

## Change
- Release matrix now builds **both** bins and maps each to its registry repo:
  - `indexer` (services crate) → `availj/vectorx-indexer`
  - `operator` (script crate) → `availj/vector-operator-job`
- `Dockerfile`: `ENV BIN_MODE_ENV=$BIN_MODE` so each image's default CMD targets its own binary (the old image left this hardcoded to `indexer`; harmless for the fallback job which overrides the entrypoint, but this makes the operator image self-consistent). Indexer image behavior unchanged.
- Runner kept on GitHub-hosted `ubuntu-24.04` (the build runs inside the container, so no SP1 toolchain needed on the host).

## After merge
Re-trigger the release for the desired tag (e.g. `workflow_dispatch` with `tag: v2.0.0-rc2`, or re-push the tag) to publish `vector-operator-job:v2.0.0-rc2`. That unblocks the turing/mainnet fallback CronJobs.