### PR TITLE
ci: add protobuf-compiler for operator image build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 ARG BUILD_PROFILE=release
 ARG BIN_MODE=indexer
 
-RUN apt update && apt install -y git make libssl-dev pkg-config libpq-dev build-essential \
+RUN apt update && apt install -y git make libssl-dev pkg-config libpq-dev build-essential protobuf-compiler \
     && cargo build --profile $BUILD_PROFILE --bin $BIN_MODE --locked \
     && cp /build/target/$BUILD_PROFILE/$BIN_MODE /build/vectorx-$BIN_MODE
 


### PR DESCRIPTION
The `operator` bin depends on `sp1-prover-types` (network prover types), whose build script runs `prost-build` and requires `protoc`. The `indexer` bin doesn't, which is why the v2.0.0-rc3 build published `vectorx-indexer` fine but the `operator`→`vector-operator-job` matrix job failed with `Could not find protoc` (exit 101).

Fix: install `protobuf-compiler` in the Dockerfile builder stage. After merge, cut a new tag to build both images.